### PR TITLE
Fix babel-runtime error

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
     "babel-core": "^5.8.25",
     "babel-eslint": "^3.1.15",
     "babel-loader": "^5.1.4",
-    "babel-runtime": "^5.8.25",
     "eslint": "^0.23",
     "eslint-config-airbnb": "0.0.6",
     "eslint-plugin-react": "^2.3.0",
@@ -44,6 +43,7 @@
     "webpack-dev-server": "^1.8.2"
   },
   "dependencies": {
+    "babel-runtime": "^5.8.25",
     "bluebird": "^2.9.34",
     "fbjs": "0.1.0-alpha.7",
     "invariant": "^2.1.0",


### PR DESCRIPTION
Trying to import the package failed with the following error:
`Error: Cannot find module 'babel-runtime/helpers/get'`

This commit moves the `babel-runtime` package to dependencies
to fix the error.

Note: reindex-cli and reindex-starter-kit were not affected because
they depend on babel-runtime themselves.
