### PR TITLE
Make queries and Relay network layer work in react-native

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
   "dependencies": {
     "babel-runtime": "^5.8.25",
     "bluebird": "^2.9.34",
+    "fbemitter": "^2.0.0",
     "fbjs": "0.1.0-alpha.7",
     "invariant": "^2.1.0",
     "isomorphic-fetch": "^2.1.1",

--- a/src/ReindexRelayNetworkLayer.js
+++ b/src/ReindexRelayNetworkLayer.js
@@ -1,6 +1,7 @@
-import fetch from 'isomorphic-fetch';
 import fetchWithRetries from './fbjs/fetchWithRetries';
 import Promise from 'bluebird';
+
+import fetch from './fetch';
 
 class ReindexRelayNetworkLayer {
 

--- a/src/fbjs/fetchWithRetries.js
+++ b/src/fbjs/fetchWithRetries.js
@@ -17,7 +17,7 @@ var ExecutionEnvironment = require('fbjs/lib/ExecutionEnvironment');
 var Promise = require('bluebird');
 
 var sprintf = require('fbjs/lib/sprintf');
-var fetch = require('isomorphic-fetch');
+var fetch = require('../fetch');
 var warning = require('fbjs/lib/warning');
 
 type InitWitRetries = {

--- a/src/fetch.js
+++ b/src/fetch.js
@@ -1,0 +1,5 @@
+const fetch = global.fetch ?
+  global.fetch.bind(global) :
+  require('isomorphic-fetch');
+
+export default fetch;

--- a/src/index.js
+++ b/src/index.js
@@ -1,8 +1,9 @@
-import { EventEmitter } from 'events';
+import { EventEmitter } from 'fbemitter';
 import ExecutionEnvironment from 'fbjs/lib/ExecutionEnvironment';
 import invariant from 'invariant';
 import Promise from 'bluebird';
-import fetch from 'isomorphic-fetch';
+
+import fetch from './fetch';
 
 let WinChan;
 if (ExecutionEnvironment.canUseDOM) {


### PR DESCRIPTION
- Replace `events` with `fbemitter`
- Detect if global fetch exists and only use `isomorphic-fetch` if not.
  `isomorphic-fetch` depends on `self` which is not available in
  react-native.
