### PR TITLE
Add .babelrc to .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -4,3 +4,4 @@ src
 test
 examples
 coverage
+.babelrc


### PR DESCRIPTION
Latest versions of react-native use Babel 6, which tries to read the
options from .babelrc in the installed reindex-js package and fails
because it has options for Babel 5. As a fix to this, remove .babelrc
from the published package by adding it to .npmignore.
(See: https://github.com/facebook/react-native/issues/4062)
