### PR TITLE
Add support for Auth0 login and `loginWithToken`

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "babel-core": "^5.8.25",
     "babel-eslint": "^3.1.15",
     "babel-loader": "^5.1.4",
+    "escope": "^3.3.0",
     "eslint": "^0.23",
     "eslint-config-airbnb": "0.0.6",
     "eslint-plugin-react": "^2.3.0",


### PR DESCRIPTION
`loginWithToken` takes an Auth0 `id_token` (JWT) and signs the user in, returning a Reindex JWT.

Example:

``` js
const lock = new Auth0Lock(clientID, domain);
lock.show((error, profile, token) => {
  Reindex.loginWithToken('auth0', token);
});
```
